### PR TITLE
Remove separate AsyncLocal for ActivityId

### DIFF
--- a/test/NonSilo.Tests/General/RequestContextTestsNonSiloRequired.cs
+++ b/test/NonSilo.Tests/General/RequestContextTestsNonSiloRequired.cs
@@ -43,7 +43,7 @@ namespace UnitTests.General
 
         private void TestCleanup()
         {
-            RequestContextTestUtils.SetActivityId(Guid.Empty);
+            RequestContextTestUtils.ClearActivityId();
             RequestContext.Clear();
             headers.Clear();
             this.fixture.RuntimeClient.ClientInvokeCallback = null;

--- a/test/TestGrains/RequestContextTestGrain.cs
+++ b/test/TestGrains/RequestContextTestGrain.cs
@@ -35,7 +35,7 @@ namespace UnitTests.Grains
 
         public Task<Guid> E2EActivityId()
         {
-            return Task.FromResult(RequestContext.ActivityId.Value);
+            return Task.FromResult(RequestContext.ActivityId);
         }
 
         public Task<Guid> E2ELegacyActivityId()
@@ -139,7 +139,7 @@ namespace UnitTests.Grains
 
         public Task<Guid> E2EActivityId()
         {
-            return Task.FromResult(RequestContext.ActivityId.Value);
+            return Task.FromResult(RequestContext.ActivityId);
         }
 
         public async Task<Tuple<string, string>> TestRequestContext()

--- a/test/Tester/TestUtils.cs
+++ b/test/Tester/TestUtils.cs
@@ -114,12 +114,20 @@ namespace Tester
     {
         public static void SetActivityId(Guid id)
         {
-            RequestContext.ActivityId.Value = id;
+            RequestContext.ActivityId = id;
         }
 
         public static Guid GetActivityId()
         {
-            return RequestContext.ActivityId.Value;
+            return RequestContext.ActivityId;
+        }
+
+        public static void ClearActivityId()
+        {
+#if !NETSTANDARD
+            Trace.CorrelationManager.ActivityId = Guid.Empty;
+#endif
+            RequestContext.ActivityId = Guid.Empty;
         }
     }
 }

--- a/test/TesterInternal/General/RequestContextTest.cs
+++ b/test/TesterInternal/General/RequestContextTest.cs
@@ -1,7 +1,6 @@
 ﻿using System;
 using System.Collections.Generic;
 using System.Diagnostics;
-using System.IO;
 using System.Runtime.Remoting.Messaging;
 using System.Threading;
 using System.Threading.Tasks;
@@ -45,13 +44,13 @@ namespace UnitTests.General
             this.runtimeClient = this.fixture.Client.ServiceProvider.GetRequiredService<OutsideRuntimeClient>();
             RequestContext.PropagateActivityId = true; // Client-side setting
 
-            RequestContextTestUtils.SetActivityId(Guid.Empty);
+            RequestContextTestUtils.ClearActivityId();
             RequestContext.Clear();
         }
         
         public void Dispose()
         {
-            RequestContextTestUtils.SetActivityId(Guid.Empty);
+            RequestContextTestUtils.ClearActivityId();
             RequestContext.Clear();
         }
 
@@ -177,6 +176,7 @@ namespace UnitTests.General
             RequestContext.Clear();
         }
 
+#if !NETSTANDARD
         [Fact, TestCategory("Functional"), TestCategory("RequestContext")]
         public async Task RequestContext_ActivityId_CM_E2E()
         {
@@ -186,14 +186,14 @@ namespace UnitTests.General
 
             IRequestContextTestGrain grain = this.fixture.GrainFactory.GetGrain<IRequestContextTestGrain>(GetRandomGrainId());
 
-            RequestContextTestUtils.SetActivityId(activityId);
-           Assert.Null(RequestContext.Get(RequestContext.E2_E_TRACING_ACTIVITY_ID_HEADER));
+            Trace.CorrelationManager.ActivityId = activityId;
+            Assert.Null(RequestContext.Get(RequestContext.E2_E_TRACING_ACTIVITY_ID_HEADER));
             Guid result = await grain.E2EActivityId();
             Assert.Equal(activityId,  result);  // "E2E ActivityId not propagated correctly"
             RequestContext.Clear();
 
-            RequestContextTestUtils.SetActivityId(nullActivityId);
-           Assert.Null(RequestContext.Get(RequestContext.E2_E_TRACING_ACTIVITY_ID_HEADER));
+            Trace.CorrelationManager.ActivityId = nullActivityId;
+            Assert.Null(RequestContext.Get(RequestContext.E2_E_TRACING_ACTIVITY_ID_HEADER));
             for (int i = 0; i < Environment.ProcessorCount; i++)
             {
                 result = await grain.E2EActivityId();
@@ -201,8 +201,8 @@ namespace UnitTests.General
             }
             RequestContext.Clear();
 
-            RequestContextTestUtils.SetActivityId(activityId2);
-           Assert.Null(RequestContext.Get(RequestContext.E2_E_TRACING_ACTIVITY_ID_HEADER));
+            Trace.CorrelationManager.ActivityId = activityId2;
+            Assert.Null(RequestContext.Get(RequestContext.E2_E_TRACING_ACTIVITY_ID_HEADER));
             result = await grain.E2EActivityId();
             Assert.Equal(activityId2,  result);  // "E2E ActivityId 2 not propagated correctly"
             RequestContext.Clear();
@@ -217,14 +217,14 @@ namespace UnitTests.General
 
             IRequestContextProxyGrain grain = this.fixture.GrainFactory.GetGrain<IRequestContextProxyGrain>(GetRandomGrainId());
 
-            RequestContextTestUtils.SetActivityId(activityId);
-           Assert.Null(RequestContext.Get(RequestContext.E2_E_TRACING_ACTIVITY_ID_HEADER));
+            Trace.CorrelationManager.ActivityId = activityId;
+            Assert.Null(RequestContext.Get(RequestContext.E2_E_TRACING_ACTIVITY_ID_HEADER));
             Guid result = await grain.E2EActivityId();
             Assert.Equal(activityId,  result);  // "E2E ActivityId not propagated correctly"
             RequestContext.Clear();
 
-            RequestContextTestUtils.SetActivityId(nullActivityId);
-           Assert.Null(RequestContext.Get(RequestContext.E2_E_TRACING_ACTIVITY_ID_HEADER));
+            Trace.CorrelationManager.ActivityId = nullActivityId;
+            Assert.Null(RequestContext.Get(RequestContext.E2_E_TRACING_ACTIVITY_ID_HEADER));
             for (int i = 0; i < Environment.ProcessorCount; i++)
             {
                 result = await grain.E2EActivityId();
@@ -232,12 +232,13 @@ namespace UnitTests.General
             }
             RequestContext.Clear();
 
-            RequestContextTestUtils.SetActivityId(activityId2);
-           Assert.Null(RequestContext.Get(RequestContext.E2_E_TRACING_ACTIVITY_ID_HEADER));
+            Trace.CorrelationManager.ActivityId = activityId2;
+            Assert.Null(RequestContext.Get(RequestContext.E2_E_TRACING_ACTIVITY_ID_HEADER));
             result = await grain.E2EActivityId();
             Assert.Equal(activityId2,  result);  // "E2E ActivityId 2 not propagated correctly"
             RequestContext.Clear();
         }
+#endif
 
         [Fact, TestCategory("Functional"), TestCategory("RequestContext")]
         public async Task RequestContext_ActivityId_RC_None_E2E()
@@ -302,15 +303,16 @@ namespace UnitTests.General
             RequestContext.Clear();
         }
 
+#if !NETSTANDARD
         [Fact, TestCategory("Functional"), TestCategory("RequestContext")]
-        public async Task RequestContext_ActivityId_DynamicChange_Client()
+        public async Task RequestContext_ActivityId_CM_DynamicChange_Client()
         {
             Guid activityId = Guid.NewGuid();
             Guid activityId2 = Guid.NewGuid();
 
             IRequestContextTestGrain grain = this.fixture.GrainFactory.GetGrain<IRequestContextTestGrain>(GetRandomGrainId());
 
-            RequestContextTestUtils.SetActivityId(activityId);
+            Trace.CorrelationManager.ActivityId = activityId;
             Guid result = await grain.E2EActivityId();
             Assert.Equal(activityId,  result);  // "E2E ActivityId #1 not propagated correctly"
             RequestContext.Clear();
@@ -318,7 +320,7 @@ namespace UnitTests.General
             RequestContext.PropagateActivityId = false;
             output.WriteLine("Set RequestContext.PropagateActivityId={0}", RequestContext.PropagateActivityId);
 
-            RequestContextTestUtils.SetActivityId(activityId2);
+            Trace.CorrelationManager.ActivityId = activityId2;
             result = await grain.E2EActivityId();
             Assert.Equal(Guid.Empty,  result);  // "E2E ActivityId #2 not not have been propagated"
             RequestContext.Clear();
@@ -326,12 +328,12 @@ namespace UnitTests.General
             RequestContext.PropagateActivityId = true;
             output.WriteLine("Set RequestContext.PropagateActivityId={0}", RequestContext.PropagateActivityId);
 
-            RequestContextTestUtils.SetActivityId(activityId2);
+            Trace.CorrelationManager.ActivityId = activityId2;
             result = await grain.E2EActivityId();
             Assert.Equal(activityId2,  result);  // "E2E ActivityId #2 should have been propagated"
             RequestContext.Clear();
 
-            RequestContextTestUtils.SetActivityId(activityId);
+            Trace.CorrelationManager.ActivityId = activityId;
             result = await grain.E2EActivityId();
             Assert.Equal(activityId,  result);  // "E2E ActivityId #1 not propagated correctly after #2"
             RequestContext.Clear();
@@ -339,7 +341,7 @@ namespace UnitTests.General
 
         [Fact(Skip = "Silo setting update of PropagateActivityId is not correctly implemented")]
         [TestCategory("Functional"), TestCategory("RequestContext")]
-        public async Task RequestContext_ActivityId_DynamicChange_Server()
+        public async Task RequestContext_ActivityId_CM_DynamicChange_Server()
         {
             Guid activityId = Guid.NewGuid();
             Guid activityId2 = Guid.NewGuid();
@@ -380,6 +382,7 @@ namespace UnitTests.General
             Assert.Equal(activityId,  result);  // "E2E ActivityId #1 not propagated correctly after #2"
             RequestContext.Clear();
         }
+#endif
 
         [Fact, TestCategory("Functional"), TestCategory("RequestContext")]
         public async Task ClientInvokeCallback_CountCallbacks()


### PR DESCRIPTION
Simplify handling and fallbacks of ActivityIDs to something similar to how it was before the move to AsyncLocal.
Add RequestContext.ActivityId property for ease of flowing an end-to-end activity ID even in .NET Standard, where Trace.CorrelationManager.ActivityId does not exist.
Avoid setting an explicit null value if the AsyncLocal is already null when clearing.